### PR TITLE
Filters modal integration

### DIFF
--- a/app/ExploreDecks.tsx
+++ b/app/ExploreDecks.tsx
@@ -1,68 +1,39 @@
 import DeckCard from 'components/DeckCover';
 import FiltersModal, { visibilityCallback } from 'components/FiltersModal';
+import { DecksProvider, useDecks } from 'components/DecksContext';
 import { router } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { FlatList, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import BackIcon from '../assets/back-icon.svg';
 
-const ExploreDecks: React.FC = () => {
-  const decks = [
-    { id: 'platforms_easy', category: 'platforms_and_privacy', difficulty: 'easy', progress: 0.0 },
-    {
-      id: 'platforms_medium',
-      category: 'platforms_and_privacy',
-      difficulty: 'medium',
-      progress: 0.0,
-    },
-    { id: 'platforms_hard', category: 'platforms_and_privacy', difficulty: 'hard', progress: 0.0 },
+const categoryToDeckCardFormat: { [key: string]: string } = {
+  'Platforms and Privacy': 'platforms_and_privacy',
+  'Online Interactions': 'online_interactions',
+  'Inappropriate Content': 'inappropriate_content',
+  'Social Media and Mental Health': 'social_media_and_mental_health',
+  'Screentime': 'screen_time',
+};
 
-    { id: 'online_easy', category: 'online_interactions', difficulty: 'easy', progress: 0.0 },
-    { id: 'online_medium', category: 'online_interactions', difficulty: 'medium', progress: 0.0 },
-    { id: 'online_hard', category: 'online_interactions', difficulty: 'hard', progress: 0.0 },
+const difficultyToDeckCardFormat = (difficulty: string): 'easy' | 'medium' | 'hard' => {
+  const lower = difficulty.toLowerCase();
+  if (lower === 'easy') return 'easy';
+  if (lower === 'medium') return 'medium';
+  if (lower === 'hard') return 'hard';
+  return 'easy'; // default
+};
 
-    {
-      id: 'inappropriate_easy',
-      category: 'inappropriate_content',
-      difficulty: 'easy',
-      progress: 0.0,
-    },
-    {
-      id: 'inappropriate_medium',
-      category: 'inappropriate_content',
-      difficulty: 'medium',
-      progress: 0.0,
-    },
-    {
-      id: 'inappropriate_hard',
-      category: 'inappropriate_content',
-      difficulty: 'hard',
-      progress: 0.0,
-    },
+const ExploreDecksContent: React.FC = () => {
+  const { filteredDecks } = useDecks();
 
-    {
-      id: 'social_easy',
-      category: 'social_media_and_mental_health',
-      difficulty: 'easy',
-      progress: 0.0,
-    },
-    {
-      id: 'social_medium',
-      category: 'social_media_and_mental_health',
-      difficulty: 'medium',
-      progress: 0.0,
-    },
-    {
-      id: 'social_hard',
-      category: 'social_media_and_mental_health',
-      difficulty: 'hard',
-      progress: 0.0,
-    },
-
-    { id: 'screen_easy', category: 'screen_time', difficulty: 'easy', progress: 0.0 },
-    { id: 'screen_medium', category: 'screen_time', difficulty: 'medium', progress: 0.0 },
-    { id: 'screen_hard', category: 'screen_time', difficulty: 'hard', progress: 0.0 },
-  ];
+  const decks = useMemo(() => {
+    return filteredDecks.map((deck) => ({
+      id: `deck_${deck.id}`,
+      category: categoryToDeckCardFormat[deck.category] || deck.category.toLowerCase().replace(/\s+/g, '_'),
+      difficulty: difficultyToDeckCardFormat(deck.difficulty),
+      progress: 0.0, // Default progress
+    }));
+  }, [filteredDecks]);
 
   const { width: screenWidth } = useWindowDimensions();
 
@@ -70,12 +41,6 @@ const ExploreDecks: React.FC = () => {
   const pad = 24;
   const numColumns = 2;
   const itemWidth = Math.floor((screenWidth - pad * 2 - gap * (numColumns - 1)) / numColumns);
-  const [showOverlay, setShowOverlay] = useState(false);
-
-  useEffect(() => {
-    visibilityCallback(setShowOverlay);
-  }, []);
-
   const [showOverlay, setShowOverlay] = useState(false);
 
   useEffect(() => {
@@ -97,10 +62,6 @@ const ExploreDecks: React.FC = () => {
 
         <FiltersModal />
       </View>
-      {showOverlay && (
-        <View className="absolute inset-0 bg-[rgba(0,0,0,0.3)]" pointerEvents="none" />
-      )}
-
       {showOverlay && (
         <View className="absolute inset-0 bg-[rgba(0,0,0,0.3)]" pointerEvents="none" />
       )}
@@ -134,6 +95,14 @@ const ExploreDecks: React.FC = () => {
         }}
       />
     </SafeAreaView>
+  );
+};
+
+const ExploreDecks: React.FC = () => {
+  return (
+    <DecksProvider>
+      <ExploreDecksContent />
+    </DecksProvider>
   );
 };
 

--- a/components/DecksContext.tsx
+++ b/components/DecksContext.tsx
@@ -1,0 +1,104 @@
+import React, { createContext, useContext, useState, useMemo, ReactNode } from 'react';
+import { getAllDecks, getFilteredDecks } from '../services/dataService';
+
+interface DecksContextType {
+  selectedTopics: string[];
+  selectedDifficulties: string[];
+  filteredDecks: any[];
+  
+  topics: string[];
+  difficulties: string[];
+  
+  setSelections: (selections: { topics?: string[]; difficulty?: string[] }) => void;
+  toggleTopic: (topic: string) => void;
+  setDifficulty: (difficulty: string) => void;
+  clearFilters: () => void;
+  
+  setSelectedTopics: (topics: string[]) => void;
+  setSelectedDifficulties: (difficulties: string[]) => void;
+}
+
+const DecksContext = createContext<DecksContextType | undefined>(undefined);
+
+interface DecksProviderProps {
+  children: ReactNode;
+}
+
+export const DecksProvider: React.FC<DecksProviderProps> = ({ children }) => {
+  const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
+  const [selectedDifficulties, setSelectedDifficulties] = useState<string[]>([]);
+
+  const allDecks = useMemo(() => getAllDecks(), []);
+
+  const topics = useMemo(() => {
+    const categories = allDecks.map((deck) => deck.category);
+    return Array.from(new Set(categories));
+  }, [allDecks]);
+
+  const difficulties = useMemo(() => {
+    const difficultyLevels = allDecks.map((deck) => deck.difficulty);
+    return Array.from(new Set(difficultyLevels));
+  }, [allDecks]);
+
+  const filteredDecks = useMemo(() => {
+    return getFilteredDecks(selectedTopics, selectedDifficulties);
+  }, [selectedTopics, selectedDifficulties]);
+
+  const setSelections = (selections: { topics?: string[]; difficulty?: string[] }) => {
+    if (selections.topics !== undefined) {
+      setSelectedTopics(selections.topics);
+    }
+    if (selections.difficulty !== undefined) {
+      setSelectedDifficulties(selections.difficulty);
+    }
+  };
+
+  const toggleTopic = (topic: string) => {
+    setSelectedTopics((prev) => {
+      if (prev.includes(topic)) {
+        return prev.filter((t) => t !== topic);
+      } else {
+        return [...prev, topic];
+      }
+    });
+  };
+
+  const setDifficulty = (difficulty: string) => {
+    setSelectedDifficulties((prev) => {
+      if (prev.includes(difficulty)) {
+        return prev.filter((d) => d !== difficulty);
+      } else {
+        return [...prev, difficulty];
+      }
+    });
+  };
+
+  const clearFilters = () => {
+    setSelectedTopics([]);
+    setSelectedDifficulties([]);
+  };
+
+  const value: DecksContextType = {
+    selectedTopics,
+    selectedDifficulties,
+    filteredDecks,
+    topics,
+    difficulties,
+    setSelections,
+    toggleTopic,
+    setDifficulty,
+    clearFilters,
+    setSelectedTopics,
+    setSelectedDifficulties,
+  };
+
+  return <DecksContext.Provider value={value}>{children}</DecksContext.Provider>;
+};
+
+export const useDecks = (): DecksContextType => {
+  const context = useContext(DecksContext);
+  if (context === undefined) {
+    throw new Error('useDecks must be used within a DecksProvider');
+  }
+  return context;
+};

--- a/components/FiltersModal.tsx
+++ b/components/FiltersModal.tsx
@@ -222,3 +222,5 @@ const FiltersModal = () => {
 };
 
 export default FiltersModal;
+
+

--- a/components/FiltersModal.tsx
+++ b/components/FiltersModal.tsx
@@ -177,11 +177,11 @@ const FiltersModal = () => {
                         }`}
                         onPress={() => toggleTopic(topic.id)}>
                         <Text
-                          className={`font-jost-medium text-xl ${isChecked ? 'text-white' : 'text-black'}`}>
+                          className={`font-jost-regular text-xl ${isChecked ? 'text-white' : 'text-black'}`}>
                           {topic.label}
                         </Text>
                         <Text
-                          className={`font-jost-medium text-2xl ${isChecked ? 'text-white' : 'text-black'}`}>
+                          className={`font-jost-regular text-2xl ${isChecked ? 'text-white' : 'text-black'}`}>
                           {isChecked ? '−' : '+'}
                         </Text>
                       </Pressable>
@@ -218,11 +218,11 @@ const FiltersModal = () => {
                         }`}
                         onPress={() => toggleDifficulty(level)}>
                         <Text
-                          className={`font-jost-medium text-xl capitalize ${isSelected ? 'text-white' : 'text-black'}`}>
+                          className={`font-jost-regular text-xl capitalize ${isSelected ? 'text-white' : 'text-black'}`}>
                           {level}
                         </Text>
                         <Text
-                          className={`font-jost-medium text-2xl ${isSelected ? 'text-white' : 'text-black'}`}>
+                          className={`font-jost-regular text-2xl ${isSelected ? 'text-white' : 'text-black'}`}>
                           {isSelected ? '−' : '+'}
                         </Text>
                       </Pressable>

--- a/components/FiltersModal.tsx
+++ b/components/FiltersModal.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Modal, Pressable, Text, View } from 'react-native';
+import { useDecks } from './DecksContext';
 import BackIcon from '../assets/back-icon.svg';
 import FilterIcon from '../assets/filter-icon.svg';
 
@@ -17,6 +18,24 @@ const topics: Topic[] = [
   { id: 'privacy', label: 'Platforms and Privacy' },
 ];
 
+// Map topic IDs to category names from JSON
+const topicIdToCategory: { [key: string]: string } = {
+  'inappropriate': 'Inappropriate Content',
+  'online': 'Online Interactions',
+  'screen': 'Screentime',
+  'mental': 'Social Media and Mental Health',
+  'privacy': 'Platforms and Privacy',
+};
+
+// Map category names to topic IDs
+const categoryToTopicId: { [key: string]: string } = {
+  'Inappropriate Content': 'inappropriate',
+  'Online Interactions': 'online',
+  'Screentime': 'screen',
+  'Social Media and Mental Health': 'mental',
+  'Platforms and Privacy': 'privacy',
+};
+
 let onModalVisibilityChange: ((visible: boolean) => void) | null = null;
 
 export const visibilityCallback = (callback: (visible: boolean) => void) => {
@@ -31,10 +50,32 @@ const difficulties = [
 ];
 
 const FiltersModal = () => {
+  const { topics: contextTopics, difficulties: contextDifficulties, selectedTopics: contextSelectedTopics, selectedDifficulties: contextSelectedDifficulties, setSelections } = useDecks();
+  
   const [modalVisible, setModalVisible] = useState(false);
-  const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
-  const [selectedDifficulties, setSelectedDifficulties] = useState<string[]>([]);
+  const [pendingTopics, setPendingTopics] = useState<string[]>([]);
+  const [pendingDifficulties, setPendingDifficulties] = useState<string[]>([]);
   const [filterStep, setFilterStep] = useState<'topics' | 'difficulty'>('topics');
+
+  // Initialize pending state from context when modal opens
+  useEffect(() => {
+    if (modalVisible) {
+      // Convert context categories to topic IDs
+      const topicIds = contextSelectedTopics
+        .map(category => categoryToTopicId[category])
+        .filter((id): id is string => id !== undefined);
+      setPendingTopics(topicIds);
+      
+      // Map context difficulties to modal format
+      const difficultyLabels = contextSelectedDifficulties.map(diff => {
+        if (diff === 'Easy') return 'Easy (8 or older)';
+        if (diff === 'Medium') return 'Medium (11 or older)';
+        if (diff === 'Hard') return 'Hard (13 or older)';
+        return diff;
+      });
+      setPendingDifficulties(difficultyLabels);
+    }
+  }, [modalVisible, contextSelectedTopics, contextSelectedDifficulties]);
 
   const toggleModal = (visible: boolean) => {
     setModalVisible(visible);
@@ -45,7 +86,7 @@ const FiltersModal = () => {
   };
 
   const toggleTopic = (id: string) => {
-    setSelectedTopics((prev) => {
+    setPendingTopics((prev) => {
       let newSelection: string[];
       if (id === 'all') {
         if (prev.includes('all')) {
@@ -67,7 +108,7 @@ const FiltersModal = () => {
   };
 
   const toggleDifficulty = (level: string) => {
-    setSelectedDifficulties((prev) => {
+    setPendingDifficulties((prev) => {
       let newSelection: string[];
       if (level === 'All Difficulties') {
         if (prev.includes('All Difficulties')) {
@@ -79,7 +120,6 @@ const FiltersModal = () => {
         newSelection = prev.includes(level) ? prev.filter((d) => d !== level) : [...prev, level];
         newSelection = newSelection.filter((d) => d !== 'All Difficulties');
 
-        // If all individual difficulties are selected, automatically select "All Difficulties"
         const individualDifficulties = difficulties.filter((diff) => diff !== 'All Difficulties');
         if (individualDifficulties.every((diff) => newSelection.includes(diff))) {
           newSelection = difficulties;
@@ -128,7 +168,7 @@ const FiltersModal = () => {
 
                 <View className="w-full flex-1 gap-4">
                   {topics.map((topic) => {
-                    const isChecked = selectedTopics.includes(topic.id);
+                    const isChecked = pendingTopics.includes(topic.id);
                     return (
                       <Pressable
                         key={topic.id}
@@ -169,7 +209,7 @@ const FiltersModal = () => {
 
                 <View className="w-full flex-1 gap-4">
                   {difficulties.map((level) => {
-                    const isSelected = selectedDifficulties.includes(level);
+                    const isSelected = pendingDifficulties.includes(level);
                     return (
                       <Pressable
                         key={level}
@@ -190,7 +230,6 @@ const FiltersModal = () => {
                   })}
                 </View>
 
-                {/* Footer with Back and Apply */}
                 <View className="flex-row items-center justify-between gap-2 self-stretch py-8">
                   <Pressable
                     className="flex-row items-center gap-1"
@@ -203,9 +242,29 @@ const FiltersModal = () => {
                   <Pressable
                     className="items-center justify-center rounded-full bg-[#AEC4D0] px-4 py-2"
                     onPress={() => {
+                      // Convert pending topics to categories
+                      const categories = pendingTopics
+                        .filter(id => id !== 'all')
+                        .map(id => topicIdToCategory[id])
+                        .filter((cat): cat is string => cat !== undefined);
+                      
+                      // Convert pending difficulties to context format
+                      const contextDifficulties = pendingDifficulties
+                        .filter(diff => diff !== 'All Difficulties')
+                        .map(diff => {
+                          if (diff.includes('Easy')) return 'Easy';
+                          if (diff.includes('Medium')) return 'Medium';
+                          if (diff.includes('Hard')) return 'Hard';
+                          return diff;
+                        });
+                      
+                      // Commit selections to context
+                      setSelections({
+                        topics: categories,
+                        difficulty: contextDifficulties,
+                      });
+                      
                       toggleModal(false);
-                      console.log('Selected Topics:', selectedTopics);
-                      console.log('Selected Difficulties:', selectedDifficulties);
                     }}>
                     <Text className="font-jost-bold text-base leading-5 text-black">
                       Set Difficulty

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -1,5 +1,48 @@
 import safetyData from '../data/act_safety_decks.json';
 
+
+/**
+ * Get all decks from the JSON file.
+ */
+export const getAllDecks = () => {
+  return safetyData.decks || [];
+};
+
+
+export const getFilteredDecks = (selectedTopics?: string[], selectedDifficulties?: string[]) => {
+  let filtered = safetyData.decks;
+
+  if (selectedTopics && selectedTopics.length > 0) {
+    filtered = filtered.filter((deck) => selectedTopics.includes(deck.category));
+  }
+
+  if (selectedDifficulties && selectedDifficulties.length > 0) {
+    filtered = filtered.filter((deck) => selectedDifficulties.includes(deck.difficulty));
+  }
+
+  return filtered;
+};
+
+/**
+ * Return a list of unique topic categories.
+ */
+export const getUniqueTopics = () => {
+  const allDecks = getAllDecks();
+  const topics = allDecks.map((deck) => deck.category);
+  return Array.from(new Set(topics));
+};
+
+/**
+ * Return a list of unique difficulty levels.
+ */
+export const getUniqueDifficulties = () => {
+  const allDecks = getAllDecks();
+  const difficulties = allDecks.map((deck) => deck.difficulty);
+  return Array.from(new Set(difficulties));
+};
+
+
+
 export const getCardData = (cardId: number) => {
   for (const deck of safetyData["decks"]) {
      for (const card of deck["cards"]) {


### PR DESCRIPTION
## Description

Added the filter implementation as described in the PR. Nalini and I centralized the data access, made a shared state hook and implemented the filter function in the filter modal and explore deck screen.


## Related Issue
Closes #35

## Changes Made

Briefly describe the changes made:_

- Backed to filter feature made
- Dataservice.ts links to json
- DecksContexts.tsx helps to link that data as callable functions for front end
- UI linked to backend in FilterModal and ExploreDecks


## Acceptance Criteria Checklist

- Single Source of Truth: Only dataService.ts imports the JSON and handles all filtering logic.
- Shared Context: A working DecksContext / useDecks hook exposes decks, topics, and difficulties to all components.
- Functional Filtering: Selecting Topics and Difficulty in the modal updates filteredDecks on Explore Decks.
- Persistent State: Filters remain active and visually highlighted when reopening the modal.
- Reset Behavior: “All Topics” or “All Difficulties” resets filters to show all decks.
- Decoupled Components: Explore Decks and Filters Modal never access raw JSON directly — only through useDecks().
- Parity with Design: All UI matches Figma design and uses NativeWind classes.


## Screenshots


https://github.com/user-attachments/assets/1e2bd4f0-bc44-4dde-b982-60c238bf111b


## Reviewer Notes

n/a
